### PR TITLE
Add create operator page for admin

### DIFF
--- a/resources/js/Pages/Auth/CreateOperator.vue
+++ b/resources/js/Pages/Auth/CreateOperator.vue
@@ -1,0 +1,128 @@
+<script setup>
+import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout.vue';
+import InputError from '@/Components/InputError.vue';
+import InputLabel from '@/Components/InputLabel.vue';
+import PrimaryButton from '@/Components/PrimaryButton.vue';
+import TextInput from '@/Components/TextInput.vue';
+import { Head, Link, useForm } from '@inertiajs/vue3';
+import VueMultiselect from 'vue-multiselect'
+import { useTrans } from '@/composables/trans';
+
+defineProps({ areas_opts: Object })
+
+const form = useForm({
+    name: '',
+    email: '',
+    phone: '',
+    areas: null,
+    password: '',
+    password_confirmation: '',
+});
+
+const submit = () => {
+    form.post(route('operator_store_by_admin'), {
+        onFinish: () => form.reset('password', 'password_confirmation'),
+    });
+};
+
+function nameWithType({name, type}) {
+    return (type === 'provincia') ? `${name} (${type})` : `${name}`
+}
+
+</script>
+
+<template>
+    <AuthenticatedLayout>
+        <Head title="Create Operator" />
+        <div class="text-lg text-center my-3">Crea un nuovo Operatore</div>
+        <form @submit.prevent="submit">
+            <div>
+                <InputLabel for="name" :value="useTrans('Name')" />
+                <TextInput
+                    id="name"
+                    type="text"
+                    class="mt-1 block w-full"
+                    v-model="form.name"
+                    autofocus
+                    autocomplete="name"
+                />
+                <InputError class="mt-2" :message="form.errors.name" />
+            </div>
+            <div class="mt-4">
+                <InputLabel for="email" value="Email" />
+                <TextInput
+                    id="email"
+                    type="text"
+                    class="mt-1 block w-full"
+                    v-model="form.email"
+                    autocomplete="username"
+                />
+                <InputError class="mt-2" :message="form.errors.email" />
+            </div>
+            <div class="mt-4">
+                <InputLabel for="phone" :value="useTrans('Phone')" />
+                <TextInput
+                    id="phone"
+                    type="text"
+                    class="mt-1 block w-full"
+                    v-model="form.phone"
+                    autocomplete="phone"
+                />
+                <InputError class="mt-2" :message="form.errors.phone" />
+            </div>
+            <div class="mt-4 text-center my-4 py-4">
+                <InputLabel  class="mx-3 my-6 px-4 text-base" for="areas" value="Seleziona una o più Aree Geografiche da cui ricevere le richieste di Preventivo" />
+                <div class="text-sm/relaxed text-gray-400">Cerca Provincia - Regione - Tutta Italia - Estero</div>
+                <vue-multiselect
+                    v-model="form.areas"
+                    :options="areas_opts"
+                    :multiple="true"
+                    placeholder="Cerca una o più aree geografiche (Provincia o Regione)"
+                    label="name"
+                    track-by="name"
+                    :custom-label="nameWithType">
+                </vue-multiselect>
+                <InputError class="mt-2" :message="form.errors.areas" />
+            </div>
+            <div class="mt-4">
+                <InputLabel for="password" value="Password" />
+                <TextInput
+                    id="password"
+                    type="password"
+                    class="mt-1 block w-full"
+                    v-model="form.password"
+                    autocomplete="new-password"
+                />
+                <InputError class="mt-2" :message="form.errors.password" />
+            </div>
+
+            <div class="mt-4">
+                <InputLabel for="password_confirmation" :value="useTrans('Password Confirmation')" />
+                <TextInput
+                    id="password_confirmation"
+                    type="password"
+                    class="mt-1 block w-full"
+                    v-model="form.password_confirmation"
+                    autocomplete="new-password"
+                />
+                <InputError class="mt-2" :message="form.errors.password_confirmation" />
+            </div>
+
+            <div class="flex items-center justify-end my-6 pt-4">
+                <Link
+                    :href="route('operators')"
+                    class="underline text-sm text-gray-600 hover:text-gray-900 rounded-md focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
+                >
+                    {{ useTrans('Back to Operators') }}
+                </Link>
+
+                <PrimaryButton class="ms-4" :class="{ 'opacity-25': form.processing }" :disabled="form.processing">
+                    {{ useTrans('Create Operator') }}
+                </PrimaryButton>
+            </div>
+        </form>
+    </AuthenticatedLayout>
+</template>
+
+<!-- Add Multiselect CSS. Can be added as a static asset or inside a component. -->
+<style src="vue-multiselect/dist/vue-multiselect.min.css"></style>

--- a/routes/web.php
+++ b/routes/web.php
@@ -8,6 +8,7 @@ use App\Http\Controllers\ProfileController;
 use App\Http\Controllers\QuotesController;
 use App\Http\Controllers\TransactionsController;
 use App\Http\Controllers\UsersController;
+use App\Http\Controllers\Auth\RegisteredOperatorController;
 use Illuminate\Foundation\Application;
 use Illuminate\Support\Facades\Route;
 use Inertia\Inertia;
@@ -23,6 +24,8 @@ Route::middleware(['auth', 'verified'])->group(function () {
     Route::get('/dashboard', [DashboardController::class, 'dashboard'])->name('dashboard');
     // operators
     Route::get('/operators', [OperatorsController::class, 'operators'])->name('operators');
+    Route::get('/operators/create', [RegisteredOperatorController::class, 'createByAdmin'])->name('operator_create_by_admin');
+    Route::post('/operators/store', [RegisteredOperatorController::class, 'storeByAdmin'])->name('operator_store_by_admin');
     // leads
     Route::get('/leads', [LeadsController::class, 'leads'])->name('leads');
     // users


### PR DESCRIPTION
Add a dedicated page for admin to create a new operator.

* **Controller Changes**
  - Add `createByAdmin` method in `RegisteredOperatorController` to display the create operator view for admin.
  - Add `storeByAdmin` method in `RegisteredOperatorController` to handle the storage of an operator created by admin.

* **Vue Component**
  - Create `CreateOperator.vue` for the admin to create an operator.
  - Include form fields for `name`, `email`, `phone`, `areas`, `password`, and `password_confirmation`.
  - Use `vue-multiselect` for selecting multiple areas.

* **Routes**
  - Add a route in `web.php` for the admin to access the create operator page.
  - Add a route in `web.php` for the admin to store the created operator.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/alessandrofuda/pvapp?shareId=9e231b76-627e-4810-9a78-3a254467ecc5).